### PR TITLE
Update eval-source-map-dev-tool-plugin.mdx

### DIFF
--- a/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
@@ -16,7 +16,7 @@ related:
     url: https://survivejs.com/webpack/building/source-maps/#sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin
 ---
 
-EvalSourceMapDevToolPlugin을 사용하면 소스 맵 생성을 보다 세밀하게 제어할 수 있습니다. 또한 [`devtool`](/configuration/devtool/) 설정 옵션의 특정한 세팅에 의해 자동으로 활성화됩니다.
+EvalSourceMapDevToolPlugin을 사용하면 소스맵 생성을 보다 세밀하게 제어할 수 있습니다. 또한 [`devtool`](/configuration/devtool/) 설정 옵션의 특정한 세팅에 의해 자동으로 활성화됩니다.
 
 ```js
 new webpack.EvalSourceMapDevToolPlugin(options);
@@ -26,22 +26,22 @@ new webpack.EvalSourceMapDevToolPlugin(options);
 
 다음과 같은 옵션이 지원됩니다:
 
-- `test` (`string|RegExp|array`): 모듈의 확장자를 기반으로 하는 소스 맵을 포함합니다(기본값은 `.js` 및 `.css`).
-- `include` (`string|RegExp|array`): 주어진 값과 일치하는 모듈 경로에 대한 소스 맵을 포함합니다.
-- `exclude` (`string|RegExp|array`): 소스 맵 생성에서 주어진 값과 일치하는 모듈을 제외합니다.
-- `append` (`string`): 원래 애셋에 주어진 값을 추가합니다. 보통 `#sourceMappingURL` 을 주석으로 합니다. `[url]`은 소스 맵 파일의 URL로 대체됩니다. 'false'는 추가를 비활성화합니다.
+- `test` (`string|RegExp|array`): 모듈의 확장자를 기반으로 하는 소스맵을 포함합니다(기본값은 `.js` 및 `.css`).
+- `include` (`string|RegExp|array`): 주어진 값과 일치하는 모듈 경로에 대한 소스맵을 포함합니다.
+- `exclude` (`string|RegExp|array`): 소스맵 생성에서 주어진 값과 일치하는 모듈을 제외합니다.
+- `append` (`string`): 원래 애셋에 주어진 값을 추가합니다. 보통 `#sourceMappingURL` 을 주석으로 합니다. `[url]`은 소스맵 파일의 URL로 대체됩니다. 'false'는 추가를 비활성화합니다.
 - `moduleFilenameTemplate` (`string`):  [`output.devtoolModuleFilenameTemplate`](/configuration/output/#outputdevtoolmodulefilenametemplate)를 참조하세요.
-- `module` (`boolean`): 로더가 소스 맵을 생성해야 하는지 여부를 나타냅니다(기본값은 `true`).
+- `module` (`boolean`): 로더가 소스맵을 생성해야 하는지 여부를 나타냅니다(기본값은 `true`).
 - `columns` (`boolean`): 열 매핑을 사용해야 하는지 여부를 나타냅니다(기본값은 `true`).
 - `protocol` (`string`): 사용자가 기본 프로토콜(`webpack-internal://`)을 오버라이드 할 수 있습니다.
 
-T> `module` 및/또는 `columns`를 `false`로 설정하면 소스 맵이 덜 정확해지지만, 컴파일 성능은 크게 향상됩니다.
+T> `module` 및/또는 `columns`를 `false`로 설정하면 소스맵이 덜 정확해지지만, 컴파일 성능은 크게 향상됩니다.
 
 T> [개발 모드](/configuration/mode/#mode-development)에서 이 플러그인에 대한 커스텀 설정을 사용하려면 기본 설정을 비활성화해야 합니다. 즉 `devtool: false`로 설정합니다.
 
 ## Examples
 
-다음 예시는 EvalSourceMapDevToolPlugin의 흔히 사용되는 사례를 보여줍니다.
+다음 예시는 EvalSourceMapDevToolPlugin이 흔히 사용되는 사례를 보여줍니다.
 
 ### Basic Use Case
 
@@ -57,7 +57,7 @@ module.exports = {
 
 ### Exclude Vendor Maps
 
-다음 코드는 `vendor.js` 번들에 있는 모든 모듈에 대한 소스 맵을 제외합니다:
+다음 코드는 `vendor.js` 번들에 있는 모든 모듈에 대한 소스맵을 제외합니다:
 
 ```js
 new webpack.EvalSourceMapDevToolPlugin({


### PR DESCRIPTION
## Summary 

// #535

## 리뷰 참고 사항

line19,29,30,31,32,34,38,60 소스 맵->소스맵
line44 
다음 예시는 EvalSourceMapDevToolPlugin의 흔히 사용되는 사례를 보여줍니다.
->다음 예시는 EvalSourceMapDevToolPlugin이 흔히 사용되는 사례를 보여줍니다.
